### PR TITLE
localStorage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -202,6 +202,16 @@ function restoreMarkerFilters() {
     teleportCategoryIds.value.forEach((id) => nextCategories.add(id))
   }
   activeCategories.value = nextCategories
+
+  const storedCollapsedGroups = storedFilters.collapsedCategoryGroups
+  if (storedCollapsedGroups && typeof storedCollapsedGroups === 'object') {
+    collapsedCategoryGroups.value = {
+      ...collapsedCategoryGroups.value,
+      ...Object.fromEntries(
+        [...collapsibleGroupLabels].map((label) => [label, Boolean(storedCollapsedGroups[label])]),
+      ),
+    }
+  }
 }
 
 function persistMarkerFilters() {
@@ -209,6 +219,9 @@ function persistMarkerFilters() {
     activeCategories: [...activeCategories.value],
     keepTeleportEnabled: keepTeleportEnabled.value,
     showIncompleteOnly: showIncompleteOnly.value,
+    collapsedCategoryGroups: Object.fromEntries(
+      [...collapsibleGroupLabels].map((label) => [label, Boolean(collapsedCategoryGroups.value[label])]),
+    ),
   }))
 }
 
@@ -769,6 +782,7 @@ watch(activeDistricts, async () => {
 }, { deep: true })
 watch(activeRouteId, () => nextTick(renderRouteArrows))
 watch([() => [...activeCategories.value], keepTeleportEnabled, showIncompleteOnly], persistMarkerFilters)
+watch(collapsedCategoryGroups, persistMarkerFilters, { deep: true })
 
 onMounted(async () => {
   await loadLatestMapData()


### PR DESCRIPTION
## Summary by Sourcery

Persist and restore the collapsed state of marker category groups in local storage alongside existing marker filter settings.

Enhancements:
- Include collapsed category group state when restoring marker filters from local storage.
- Persist collapsed category group state to local storage whenever relevant filters change.
- Trigger marker filter persistence when collapsed category groups change.